### PR TITLE
Create develop branch and add aggregate

### DIFF
--- a/aggregate.py
+++ b/aggregate.py
@@ -1,0 +1,42 @@
+'''
+Copyright (©) 2021 - Randall Simpson
+pi-iot
+
+This class is used to gather aggregate sensor metrics from a raspberry pi.
+
+Psudocode:
+If the value changes from the initial value then lets record the changes for the delay duration
+and return an average value on a per minute basis.  If the value stays the same then no reporting necessary.
+'''
+from sensor import Sensor
+from generic import Generic
+from metric import Metric
+import datetime
+import sys
+import RPi.GPIO as GPIO
+import time
+
+class Aggregate(Generic):
+    def __init__(self, source, metric_prefix, output, code, pin, metric_name, delay):
+        Generic.__init__(self, source, metric_prefix, output, code, pin, metric_name)
+        self.delay = delay
+        self.data = []
+
+    def get_info(self):
+        current_value = GPIO.input(self.pin)
+        last_change_time = time.time()
+        while current_value == self.initial_value:
+            #do nothing, wait for a change
+            current_value = GPIO.input(self.pin)
+            time.sleep(0.00001)
+        # changed
+        self.data.append(current_value)
+        current_time = time.time()
+        if current_time - last_change_time > self.delay:
+            #send metric
+            avg = sum(self.data) / len(self.data)
+            self.metrics.append(Metric(self.name, avg, datetime.datetime.utcnow()))
+            #reset time/past readings
+            last_change_time = current_time
+            self.data = []
+        self.initial_value = current_value

--- a/distance.py
+++ b/distance.py
@@ -72,7 +72,7 @@ class Distance(Sensor):
             if self.format == 'f':
                 distance = distance / 30.48
             if self.format == 'i':
-                distance = distance / 30.48 * 12;
+                distance = distance / 30.48 * 12
             self.metrics.append(Metric(name, distance, date))
 
     def format_metrics(self):

--- a/pi-iot.py
+++ b/pi-iot.py
@@ -14,6 +14,7 @@ from host import Host
 from distance import Distance
 from generic import Generic
 from motion import Motion
+from aggregate import Aggregate
 
 def send_metrics(metrics, output, webhook, source):
     try:
@@ -51,7 +52,7 @@ def run(delay, sensor_type, pin, webhook, source, metric_prefix, output, format)
         sensor = Generic(source, metric_prefix, output, sensor_type, pin, 'Tilt')
     elif sensor_type == 'YL-69':
         pin = int(pin)
-        sensor = Generic(source, metric_prefix, output, sensor_type, pin, 'Moisture')
+        sensor = Aggregate(source, metric_prefix, output, sensor_type, pin, 'Moisture', delay)
     else:
         sensor = Host(source, metric_prefix, output)
         is_polling = True


### PR DESCRIPTION
# Issue
Soil moisture metric currently causes a huge influx of metrics due to the rapid changes from the sensor when it is changing from wet to dry.

## Queue Size
![image](https://user-images.githubusercontent.com/44104721/115118179-4ac3fd80-9f5f-11eb-8cc0-0059e8020c67.png)

## Moisture Readings
![image](https://user-images.githubusercontent.com/44104721/115118341-f2d9c680-9f5f-11eb-9d8f-d928a4ae32ac.png)

# Solution
Instead of an influx of metrics, send out an average metric using a specific time interval.  Time interval is imported as `delay` parameter, if no value is passed in it is set to 1 second.