### PR TITLE
Added fix for moisture sensor

### DIFF
--- a/moisture.py
+++ b/moisture.py
@@ -23,35 +23,33 @@ class Moisture(Generic):
     def __init__(self, source, metric_prefix, output, code, pin, metric_name, delay):
         Generic.__init__(self, source, metric_prefix, output, code, pin, metric_name)
         self.delay = delay
-        self.data = []
+        self.has_changed = False
 
     def get_info(self):
         current_value = GPIO.input(self.pin)
         last_change_time = time.time()
+        current_time = time.time()
         while current_value == self.initial_value:
             #do nothing, wait for a change
             current_value = GPIO.input(self.pin)
             time.sleep(0.00001)
-            if len(self.data) > 0 and time.time() - last_change_time > self.delay:
-                val = len(self.data) / 1500
-                if current_value == 1:
-                    val = 1.0 - val
-                logger.debug(f'val: {val}, length: {len(self.data)}')
-                self.metrics.append(Metric(self.name, val, datetime.datetime.utcnow()))
+            current_time = time.time()
+            # this case is when the flapping stops inbetween delay
+            if self.has_changed and current_time - last_change_time > self.delay + 1:
+                self.metrics.append(Metric(self.name, 0.5, datetime.datetime.utcnow()))
                 #reset past readings and set initial value so if it's at 0.5 it can be corrected to 0 or 1
-                self.data = []
-                self.initial_value = val
-        # changed
-        self.data.append(current_value)
-        current_time = time.time()
+                self.has_changed = False
+                self.initial_value = 0.5
+                #set a delay to buffer then end result value
+                time.sleep(self.delay)
+        # value changed
         if current_time - last_change_time > self.delay:
             #send metric
-            val = len(self.data) / 1500
-            if current_value == 1:
-                val = 1.0 - val
-            logger.debug(f'val: {val}, length: {len(self.data)}')
+            val = 0.5 if self.has_changed else current_value
             self.metrics.append(Metric(self.name, val, datetime.datetime.utcnow()))
             #reset time/past readings
             last_change_time = current_time
-            self.data = []
+            self.has_changed = False
+        else:
+            self.has_changed = True
         self.initial_value = current_value


### PR DESCRIPTION
# Issue
Moisture sensor readings are going above 1 or lower than 0.  This is because the denominator is not large enough to handle the flapping.  Also when there is a large number of flapping that would indicate that the sensor should report a .5, current logic would return a value close to 1.

![image](https://user-images.githubusercontent.com/44104721/115149594-18c79f80-a022-11eb-83c2-d0498b42335e.png)

# Solution
This solution would return a 0.5 if there is flapping, but would return a 1 or a 0 if there is not.